### PR TITLE
check if the sws_scaler have initialized only once

### DIFF
--- a/src/video_reader.cpp
+++ b/src/video_reader.cpp
@@ -143,10 +143,10 @@ bool video_reader_read_frame(VideoReaderState* state, uint8_t* frame_buffer, int
         sws_scaler_ctx = sws_getContext(width, height, source_pix_fmt,
                                         width, height, AV_PIX_FMT_RGB0,
                                         SWS_BILINEAR, NULL, NULL, NULL);
-    }
-    if (!sws_scaler_ctx) {
-        printf("Couldn't initialize sw scaler\n");
-        return false;
+        if (!sws_scaler_ctx) {
+            printf("Couldn't initialize sw scaler\n");
+            return false;
+        }
     }
 
     uint8_t* dest[4] = { frame_buffer, NULL, NULL, NULL };


### PR DESCRIPTION
There is no need to check if the sws_scaler have initialized every frame, only when we attempt to initialize it.
it's not a major change, but maybe it's a bit more efficient?